### PR TITLE
fix: remove action params

### DIFF
--- a/docs/译文/build_your_own_react.md
+++ b/docs/译文/build_your_own_react.md
@@ -1363,7 +1363,7 @@ function useState(initial){
   }
   const actions = oldHook ? oldHook.queue : []
   actions.forEach(action => {
-    hook.state = action(hook.state)
+    hook.state = action
   })
   const setState = action => {
     hook.queue.push(action)


### PR DESCRIPTION
在setState(action)中，action是state的一个值，因此在actions遍历赋值的过程中，应该直接赋值action，action并不是一个函数。